### PR TITLE
Implement `posix_fadvise` and refine the return type of `isatty`

### DIFF
--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -79,6 +79,8 @@ pub use fd::fchmod;
 #[cfg(not(any(target_os = "netbsd", target_os = "redox", target_os = "wasi")))]
 // not implemented in libc for netbsd yet
 pub use fd::fstatfs;
+#[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
+pub use fd::posix_fallocate;
 pub use fd::{futimens, seek, tell};
 pub use file_type::FileType;
 #[cfg(any(target_os = "macos", target_os = "ios"))]

--- a/src/io/fd.rs
+++ b/src/io/fd.rs
@@ -32,28 +32,28 @@ unsafe fn _fionread(fd: RawFd) -> io::Result<u64> {
 
 /// `isatty(fd)`
 #[inline]
-pub fn isatty<Fd: AsRawFd>(fd: &Fd) -> io::Result<bool> {
+pub fn isatty<Fd: AsRawFd>(fd: &Fd) -> bool {
     let fd = fd.as_raw_fd();
     unsafe { _isatty(fd) }
 }
 
-unsafe fn _isatty(fd: RawFd) -> io::Result<bool> {
+unsafe fn _isatty(fd: RawFd) -> bool {
     let res = libc::isatty(fd as libc::c_int);
     if res == 0 {
         let err = io::Error::last_os_error();
         match err.raw_os_error() {
             #[cfg(not(target_os = "linux"))]
-            Some(libc::ENOTTY) => Ok(false),
+            Some(libc::ENOTTY) => false,
 
             // Old Linux versions reportedly return `EINVAL`.
             // https://man7.org/linux/man-pages/man3/isatty.3.html#ERRORS
             #[cfg(target_os = "linux")]
-            Some(libc::ENOTTY) | Some(libc::EINVAL) => Ok(false),
+            Some(libc::ENOTTY) | Some(libc::EINVAL) => false,
 
-            _ => Err(err),
+            _ => panic!("unexpected error from isatty: {}", err),
         }
     } else {
-        Ok(true)
+        true
     }
 }
 


### PR DESCRIPTION
This implements `posix_fadvise` on platforms that have it, plus emulation of MacOS.

And it tweaks the return type of `isatty` to simplify callers.