### PR TITLE
Support OpenBSD.

### DIFF
--- a/src/fs/dir.rs
+++ b/src/fs/dir.rs
@@ -176,14 +176,14 @@ impl Entry {
     }
 
     /// Return the inode number of this directory entry.
-    #[cfg(not(any(target_os = "freebsd", target_os = "netbsd")))]
+    #[cfg(not(any(target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")))]
     #[inline]
     pub fn ino(&self) -> u64 {
         self.dirent.d_ino
     }
 
     /// Return the inode number of this directory entry.
-    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+    #[cfg(any(target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
     #[inline]
     pub fn ino(&self) -> u64 {
         #[allow(clippy::useless_conversion)]

--- a/src/fs/fcntl.rs
+++ b/src/fs/fcntl.rs
@@ -65,6 +65,7 @@ unsafe fn _setfl(fd: UnsafeHandle, flags: OFlags) -> io::Result<()> {
     target_os = "ios",
     target_os = "macos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",
 )))]
@@ -79,6 +80,7 @@ pub fn get_seals<Fd: AsUnsafeHandle>(fd: &Fd) -> io::Result<i32> {
     target_os = "ios",
     target_os = "macos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",
 )))]

--- a/src/fs/fd.rs
+++ b/src/fs/fd.rs
@@ -25,6 +25,7 @@ use libc::lseek as libc_lseek;
     target_os = "freebsd",
     target_os = "macos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",
 )))]
@@ -34,6 +35,7 @@ use libc::off64_t as libc_off_t;
     target_os = "freebsd",
     target_os = "macos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",
 ))]
@@ -149,7 +151,7 @@ unsafe fn _futimens(fd: UnsafeHandle, times: &[libc::timespec; 2]) -> io::Result
 }
 
 /// `posix_fallocate(fd, offset, len)`
-#[cfg(not(any(target_os = "netbsd", target_os = "redox")))] // not implemented in libc for netbsd yet
+#[cfg(not(any(target_os = "netbsd", target_os = "redox", target_os = "openbsd")))] // not implemented in libc for netbsd yet
 #[inline]
 pub fn posix_fallocate<Fd: AsUnsafeHandle>(fd: &Fd, offset: u64, len: u64) -> io::Result<()> {
     let fd = fd.as_unsafe_handle();
@@ -160,6 +162,7 @@ pub fn posix_fallocate<Fd: AsUnsafeHandle>(fd: &Fd, offset: u64, len: u64) -> io
     target_os = "ios",
     target_os = "macos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox"
 )))]
 unsafe fn _posix_fallocate(fd: UnsafeHandle, offset: u64, len: u64) -> io::Result<()> {

--- a/src/fs/makedev.rs
+++ b/src/fs/makedev.rs
@@ -1,5 +1,10 @@
 /// `makedev(maj, min)`
-#[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "wasi",
+    target_os = "openbsd"
+)))]
 #[inline]
 pub fn makedev(maj: u32, min: u32) -> u64 {
     unsafe { libc::makedev(maj, min) }
@@ -22,7 +27,12 @@ pub fn makedev(maj: u32, min: u32) -> u64 {
 }
 
 /// `major(dev)`
-#[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "wasi",
+    target_os = "openbsd"
+)))]
 #[inline]
 pub fn major(dev: u64) -> u32 {
     unsafe { libc::major(dev) }
@@ -45,7 +55,12 @@ pub fn major(dev: u64) -> u32 {
 }
 
 /// `minor(dev)`
-#[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "wasi")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "wasi",
+    target_os = "openbsd"
+)))]
 #[inline]
 pub fn minor(dev: u64) -> u32 {
     unsafe { libc::minor(dev) }
@@ -68,6 +83,12 @@ pub fn minor(dev: u64) -> u32 {
 }
 
 #[test]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "wasi",
+    target_os = "openbsd"
+)))]
 fn makedev_roundtrip() {
     let maj = 0x2324_2526;
     let min = 0x6564_6361;

--- a/src/fs/makedev.rs
+++ b/src/fs/makedev.rs
@@ -1,10 +1,5 @@
 /// `makedev(maj, min)`
-#[cfg(not(any(
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "wasi",
-    target_os = "openbsd"
-)))]
+#[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "wasi")))]
 #[inline]
 pub fn makedev(maj: u32, min: u32) -> u64 {
     unsafe { libc::makedev(maj, min) }
@@ -27,12 +22,7 @@ pub fn makedev(maj: u32, min: u32) -> u64 {
 }
 
 /// `major(dev)`
-#[cfg(not(any(
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "wasi",
-    target_os = "openbsd"
-)))]
+#[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "wasi")))]
 #[inline]
 pub fn major(dev: u64) -> u32 {
     unsafe { libc::major(dev) }
@@ -55,12 +45,7 @@ pub fn major(dev: u64) -> u32 {
 }
 
 /// `minor(dev)`
-#[cfg(not(any(
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "wasi",
-    target_os = "openbsd"
-)))]
+#[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "wasi")))]
 #[inline]
 pub fn minor(dev: u64) -> u32 {
     unsafe { libc::minor(dev) }
@@ -83,12 +68,6 @@ pub fn minor(dev: u64) -> u32 {
 }
 
 #[test]
-#[cfg(not(any(
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "wasi",
-    target_os = "openbsd"
-)))]
 fn makedev_roundtrip() {
     let maj = 0x2324_2526;
     let min = 0x6564_6361;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -13,6 +13,7 @@ mod dir;
     target_os = "ios",
     target_os = "macos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox"
 )))]
 mod fadvise;
@@ -27,6 +28,7 @@ mod getpath;
     target_os = "ios",
     target_os = "freebsd",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "macos",
     target_os = "redox",
     target_os = "wasi"
@@ -66,6 +68,7 @@ pub use dir::{Dir, Entry, SeekLoc};
     target_os = "ios",
     target_os = "macos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox"
 )))]
 pub use fadvise::{fadvise, Advice};
@@ -74,6 +77,7 @@ pub use fadvise::{fadvise, Advice};
     target_os = "ios",
     target_os = "macos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "wasi",
 )))]
@@ -89,7 +93,7 @@ pub use fd::fchmod;
 #[cfg(not(any(target_os = "netbsd", target_os = "redox", target_os = "wasi")))]
 // not implemented in libc for netbsd yet
 pub use fd::fstatfs;
-#[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
+#[cfg(not(any(target_os = "netbsd", target_os = "redox", target_os = "openbsd")))]
 pub use fd::posix_fallocate;
 pub use fd::{futimens, is_file_read_write, seek, tell};
 pub use file_type::FileType;
@@ -99,6 +103,7 @@ pub use getpath::getpath;
     target_os = "ios",
     target_os = "freebsd",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "macos",
     target_os = "redox",
     target_os = "wasi"

--- a/src/time/clock.rs
+++ b/src/time/clock.rs
@@ -6,6 +6,7 @@ use std::mem::MaybeUninit;
     target_os = "ios",
     target_os = "redox",
     target_os = "freebsd",
+    target_os = "openbsd",
     target_os = "emscripten",
     target_os = "wasi",
 )))]
@@ -25,11 +26,11 @@ pub enum ClockId {
     Monotonic = libc::CLOCK_MONOTONIC,
 
     /// `CLOCK_PROCESS_CPUTIME_ID`
-    #[cfg(not(target_os = "netbsd"))]
+    #[cfg(not(any(target_os = "netbsd", target_os = "openbsd")))]
     ProcessCPUTime = libc::CLOCK_PROCESS_CPUTIME_ID,
 
     /// `CLOCK_THREAD_CPUTIME_ID`
-    #[cfg(not(target_os = "netbsd"))]
+    #[cfg(not(any(target_os = "netbsd", target_os = "openbsd")))]
     ThreadCPUTime = libc::CLOCK_THREAD_CPUTIME_ID,
 }
 
@@ -78,6 +79,7 @@ pub fn clock_gettime(id: ClockId) -> timespec {
     target_os = "ios",
     target_os = "redox",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
+    target_os = "openbsd",
     target_os = "emscripten",
     target_os = "wasi",
 )))]
@@ -98,6 +100,7 @@ pub fn clock_nanosleep_relative(id: ClockId, request: &timespec) -> Result<(), t
     target_os = "ios",
     target_os = "redox",
     target_os = "freebsd", // FreeBSD 12 has clock_nanosleep, but libc targets FreeBSD 11.
+    target_os = "openbsd",
     target_os = "emscripten",
     target_os = "wasi",
 )))]

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -16,6 +16,7 @@ pub use clock::{clock_getres, clock_gettime, ClockId};
     target_os = "ios",
     target_os = "redox",
     target_os = "freebsd",
+    target_os = "openbsd",
     target_os = "emscripten",
     target_os = "wasi",
 )))]


### PR DESCRIPTION
This basically adds OpenBSD alongside NetBSD where it appears in a target-specific configuration directive, as suggested by @sunfishcode. Verified to pass tests on OpenBSD 6.9 / x86_64. A++ easy port, would do again!