### PR TITLE
Add support for using `dup2` to replace stdin/stdout file descriptors.

### DIFF
--- a/src/imp/libc/conv.rs
+++ b/src/imp/libc/conv.rs
@@ -125,3 +125,15 @@ pub(crate) unsafe fn syscall_ret_owned_fd(raw: c_long) -> io::Result<OwnedFd> {
         Ok(OwnedFd::from_raw_fd(raw as RawFd))
     }
 }
+
+/// Convert a c_int returns from `syscall` into a file descriptor and discard
+/// it. This is used by `dup2` where the file descriptor is redundant with one
+/// of the arguments.
+#[inline]
+pub(crate) fn ret_redundant_fd(raw: c_int) -> io::Result<()> {
+    if raw == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -289,6 +289,18 @@ pub(super) unsafe fn ret_owned_fd(raw: usize) -> io::Result<OwnedFd> {
     }
 }
 
+/// Convert a c_int returns from a syscall into a file descriptor and discard
+/// it. This is used by `dup2` where the file descriptor is redundant with one
+/// of the arguments.
+#[inline]
+pub(crate) fn ret_redundant_fd(raw: usize) -> io::Result<()> {
+    if (raw as isize) < 0 {
+        Err(io::Error((raw as u16).wrapping_neg()))
+    } else {
+        Ok(())
+    }
+}
+
 #[inline]
 pub(super) fn ret_void_star(raw: usize) -> io::Result<*mut c_void> {
     check_error(raw)?;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -14,6 +14,7 @@ mod fd;
 mod ioctl;
 #[cfg(not(target_os = "wasi"))]
 mod mmap;
+#[cfg(not(target_os = "wasi"))]
 mod pipe;
 mod poll;
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -39,7 +40,7 @@ pub use ioctl::ioctl_fioclex;
 pub use ioctl::{ioctl_tcgets, ioctl_tiocgwinsz};
 #[cfg(not(target_os = "wasi"))]
 pub use mmap::{mmap, munmap, MapFlags, ProtFlags};
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(not(target_os = "wasi"))]
 pub use pipe::pipe;
 #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use pipe::{pipe_with, PipeFlags};

--- a/src/io/pipe.rs
+++ b/src/io/pipe.rs
@@ -1,13 +1,7 @@
 use crate::{imp, io};
 use io_lifetimes::OwnedFd;
 
-#[cfg(any(
-    linux_raw,
-    all(
-        libc,
-        not(any(target_os = "ios", target_os = "macos", target_os = "wasi"))
-    )
-))]
+#[cfg(any(linux_raw, all(libc, not(any(target_os = "ios", target_os = "macos")))))]
 pub use imp::io::PipeFlags;
 
 /// `pipe()`—Creates a pipe.
@@ -21,7 +15,6 @@ pub use imp::io::PipeFlags;
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/pipe.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/pipe.2.html
-#[cfg(any(target_os = "ios", target_os = "macos"))]
 #[inline]
 pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     imp::syscalls::pipe()
@@ -36,7 +29,7 @@ pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/pipe2.2.html
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
 #[inline]
 #[doc(alias = "pipe2")]
 pub fn pipe_with(flags: PipeFlags) -> io::Result<(OwnedFd, OwnedFd)> {

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 
 mod io {
+    mod dup2_to_replace_stdio;
     mod isatty;
     mod mmap;
     #[cfg(not(target_os = "redox"))] // redox doesn't have cwd/openat

--- a/tests/io/dup2_to_replace_stdio.rs
+++ b/tests/io/dup2_to_replace_stdio.rs
@@ -1,0 +1,22 @@
+/// Use `dup2` to replace the stdin and stdout file descriptors.
+#[test]
+fn dup2_to_replace_stdio() {
+    use std::io::Write;
+    use posish::io::{pipe, dup2};
+    use io_lifetimes::AsFilelike;
+
+    let (reader, writer) = pipe().unwrap();
+
+    dup2(&reader, &std::io::stdin()).unwrap();
+    dup2(&writer, &std::io::stdout()).unwrap();
+
+    drop(reader);
+    drop(writer);
+
+    // Don't use std::io::stdout() because in tests it's captured.
+    writeln!(unsafe { posish::io::stdout() }.as_filelike_view::<std::fs::File>(), "hello, world!").unwrap();
+
+    let mut s = String::new();
+    std::io::stdin().read_line(&mut s).unwrap();
+    assert_eq!(s, "hello, world!\n");
+}


### PR DESCRIPTION
One of the common use cases for `dup2` is to use it to replace stdin and
stdout with new file descriptors. Add support for this, and add a test
that does this.

This changes the signature of `dup2` to take a `BorrowedFd` to replace
rather than taking an `IntoFd` and returning an `OwnedFd`. This means
that it's no longer necessary to own the "new" fd value to replace it
with a dup of another fd, which may be more than users may be expecting
to deal with when they implement `AsFd`.

It's not yet clear that this is the right way to go.