### PR TITLE
Add support for using `dup2` to replace stdin/stdout file descriptors.

### DIFF
--- a/src/imp/libc/syscalls.rs
+++ b/src/imp/libc/syscalls.rs
@@ -1125,7 +1125,7 @@ pub(crate) unsafe fn munmap(ptr: *mut c_void, len: usize) -> io::Result<()> {
     ret(libc::munmap(ptr, len))
 }
 
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(not(target_os = "wasi"))]
 pub(crate) fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     unsafe {
         let mut result = MaybeUninit::<[OwnedFd; 2]>::uninit();

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -60,7 +60,7 @@ pub use read_write::{preadv, pwritev};
     )
 ))]
 pub use read_write::{preadv2, pwritev2, ReadWriteFlags};
-pub use stdio::{stderr, stdin, stdout};
+pub use stdio::{stderr, stdin, stdout, take_stderr, take_stdin, take_stdout};
 #[cfg(any(linux_raw, all(libc, any(target_os = "android", target_os = "linux"))))]
 pub use userfaultfd::{userfaultfd, UserFaultFdFlags};
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -14,6 +14,7 @@ mod fd;
 mod ioctl;
 #[cfg(not(target_os = "wasi"))]
 mod mmap;
+#[cfg(not(target_os = "wasi"))]
 mod pipe;
 mod poll;
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -39,7 +40,7 @@ pub use ioctl::ioctl_fioclex;
 pub use ioctl::{ioctl_tcgets, ioctl_tiocgwinsz};
 #[cfg(not(target_os = "wasi"))]
 pub use mmap::{mmap, munmap, MapFlags, ProtFlags};
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(not(target_os = "wasi"))]
 pub use pipe::pipe;
 #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
 pub use pipe::{pipe_with, PipeFlags};

--- a/src/io/pipe.rs
+++ b/src/io/pipe.rs
@@ -1,13 +1,7 @@
 use crate::{imp, io};
 use io_lifetimes::OwnedFd;
 
-#[cfg(any(
-    linux_raw,
-    all(
-        libc,
-        not(any(target_os = "ios", target_os = "macos", target_os = "wasi"))
-    )
-))]
+#[cfg(any(linux_raw, all(libc, not(any(target_os = "ios", target_os = "macos")))))]
 pub use imp::io::PipeFlags;
 
 /// `pipe()`—Creates a pipe.
@@ -21,7 +15,6 @@ pub use imp::io::PipeFlags;
 ///
 /// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/pipe.html
 /// [Linux]: https://man7.org/linux/man-pages/man2/pipe.2.html
-#[cfg(any(target_os = "ios", target_os = "macos"))]
 #[inline]
 pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     imp::syscalls::pipe()
@@ -36,7 +29,7 @@ pub fn pipe() -> io::Result<(OwnedFd, OwnedFd)> {
 ///  - [Linux]
 ///
 /// [Linux]: https://man7.org/linux/man-pages/man2/pipe2.2.html
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
 #[inline]
 #[doc(alias = "pipe2")]
 pub fn pipe_with(flags: PipeFlags) -> io::Result<(OwnedFd, OwnedFd)> {

--- a/src/io/stdio.rs
+++ b/src/io/stdio.rs
@@ -8,10 +8,13 @@
 //! stdio streams.
 #![allow(unsafe_code)]
 
-use crate::{imp, io::RawFd};
-use io_lifetimes::BorrowedFd;
+use crate::{
+    imp,
+    io::{FromRawFd, RawFd},
+};
+use io_lifetimes::{BorrowedFd, OwnedFd};
 
-/// `STDIN_FILENO`—Standard input.
+/// `STDIN_FILENO`—Standard input, borrowed.
 ///
 /// # Safety
 ///
@@ -32,7 +35,27 @@ pub unsafe fn stdin() -> BorrowedFd<'static> {
     BorrowedFd::borrow_raw_fd(imp::io::STDIN_FILENO as RawFd)
 }
 
-/// `STDOUT_FILENO`—Standard output.
+/// `STDIN_FILENO`—Standard input, owned.
+///
+/// # Safety
+///
+/// This acquires ownership of the stdin file descriptor. If it's dropped,
+/// subsequent newly created file descriptors may reuse the stdin file
+/// descriptor number, confusing code that assumes that the stdin file
+/// descriptor number is only used by stdin.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/stdin.html
+/// [Linux]: https://man7.org/linux/man-pages/man3/stdin.3.html
+#[inline]
+pub unsafe fn take_stdin() -> OwnedFd {
+    OwnedFd::from_raw_fd(imp::io::STDIN_FILENO as RawFd)
+}
+
+/// `STDOUT_FILENO`—Standard output, borrowed.
 ///
 /// # Safety
 ///
@@ -53,7 +76,27 @@ pub unsafe fn stdout() -> BorrowedFd<'static> {
     BorrowedFd::borrow_raw_fd(imp::io::STDOUT_FILENO as RawFd)
 }
 
-/// `STDERR_FILENO`—Standard error.
+/// `STDOUT_FILENO`—Standard output, owned.
+///
+/// # Safety
+///
+/// This acquires ownership of the stdout file descriptor. If it's dropped,
+/// subsequent newly created file descriptors may reuse the stdout file
+/// descriptor number, confusing code that assumes that the stdout file
+/// descriptor number is only used by stdout.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/stdout.html
+/// [Linux]: https://man7.org/linux/man-pages/man3/stdout.3.html
+#[inline]
+pub unsafe fn take_stdout() -> OwnedFd {
+    OwnedFd::from_raw_fd(imp::io::STDOUT_FILENO as RawFd)
+}
+
+/// `STDERR_FILENO`—Standard error, borrowed.
 ///
 /// # Safety
 ///
@@ -72,4 +115,24 @@ pub unsafe fn stdout() -> BorrowedFd<'static> {
 #[inline]
 pub unsafe fn stderr() -> BorrowedFd<'static> {
     BorrowedFd::borrow_raw_fd(imp::io::STDERR_FILENO as RawFd)
+}
+
+/// `STDERR_FILENO`—Standard error, owned.
+///
+/// # Safety
+///
+/// This acquires ownership of the stderr file descriptor. If it's dropped,
+/// subsequent newly created file descriptors may reuse the stderr file
+/// descriptor number, confusing code that assumes that the stderr file
+/// descriptor number is only used by stderr.
+///
+/// # References
+///  - [POSIX]
+///  - [Linux]
+///
+/// [POSIX]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/stderr.html
+/// [Linux]: https://man7.org/linux/man-pages/man3/stderr.3.html
+#[inline]
+pub unsafe fn take_stderr() -> OwnedFd {
+    OwnedFd::from_raw_fd(imp::io::STDERR_FILENO as RawFd)
 }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 
 mod io {
+    mod dup2_to_replace_stdio;
     mod isatty;
     mod mmap;
     #[cfg(not(target_os = "redox"))] // redox doesn't have cwd/openat

--- a/tests/io/dup2_to_replace_stdio.rs
+++ b/tests/io/dup2_to_replace_stdio.rs
@@ -1,0 +1,29 @@
+/// Use `dup2` to replace the stdin and stdout file descriptors.
+#[test]
+fn dup2_to_replace_stdio() {
+    use io_lifetimes::AsFilelike;
+    use posish::io::{dup2, pipe};
+    use std::io::Write;
+    use std::mem::forget;
+
+    let (reader, writer) = pipe().unwrap();
+
+    unsafe {
+        forget(dup2(&reader, posish::io::take_stdin()).unwrap());
+        forget(dup2(&writer, posish::io::take_stdout()).unwrap());
+    }
+
+    drop(reader);
+    drop(writer);
+
+    // Don't use std::io::stdout() because in tests it's captured.
+    writeln!(
+        unsafe { posish::io::stdout() }.as_filelike_view::<std::fs::File>(),
+        "hello, world!"
+    )
+    .unwrap();
+
+    let mut s = String::new();
+    std::io::stdin().read_line(&mut s).unwrap();
+    assert_eq!(s, "hello, world!\n");
+}


### PR DESCRIPTION
One of the common use cases for `dup2` is to use it to replace stdin and
stdout with new file descriptors. Add support for this, and add a test
that does this.
    
This adds new `take_stdin`, `take_stdout`, and `take_stderr` functions
which return `OwnedFd`, allowing it to be passed into `dup2`.
