### PR TITLE
Change `dup2` to take a `&OwnedFd` instead of an `IntoFd`.

### DIFF
--- a/src/imp/libc/conv.rs
+++ b/src/imp/libc/conv.rs
@@ -111,6 +111,15 @@ pub(crate) unsafe fn ret_owned_fd(raw: c_int) -> io::Result<OwnedFd> {
     }
 }
 
+#[inline]
+pub(crate) fn ret_discarded_fd(raw: c_int) -> io::Result<()> {
+    if raw == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
 /// Convert a c_long returned from `syscall` to an `OwnedFd`, if valid.
 ///
 /// # Safety

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -290,6 +290,18 @@ pub(super) unsafe fn ret_owned_fd(raw: usize) -> io::Result<OwnedFd> {
 }
 
 #[inline]
+pub(super) fn ret_discarded_fd(raw: usize) -> io::Result<()> {
+    if (raw as isize) < 0 {
+        // As above, discourage the optimizer from speculating the `Err`.
+        let raw = suppress_optimization(raw);
+
+        Err(io::Error((raw as u16).wrapping_neg()))
+    } else {
+        Ok(())
+    }
+}
+
+#[inline]
 pub(super) fn ret_void_star(raw: usize) -> io::Result<*mut c_void> {
     check_error(raw)?;
     Ok(raw as *mut c_void)

--- a/src/io/fd.rs
+++ b/src/io/fd.rs
@@ -1,7 +1,7 @@
 //! Functions which operate on file descriptors.
 
 use crate::{imp, io};
-use io_lifetimes::{AsFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, OwnedFd};
 #[cfg(all(libc, not(any(target_os = "wasi", target_os = "fuchsia"))))]
 use std::ffi::OsString;
 
@@ -94,9 +94,8 @@ pub fn dup<Fd: AsFd>(fd: &Fd) -> io::Result<OwnedFd> {
 /// [Linux]: https://man7.org/linux/man-pages/man2/dup2.2.html
 #[cfg(not(target_os = "wasi"))]
 #[inline]
-pub fn dup2<Fd: AsFd, NewFd: IntoFd>(fd: &Fd, new: NewFd) -> io::Result<OwnedFd> {
+pub fn dup2<Fd: AsFd>(fd: &Fd, new: &OwnedFd) -> io::Result<()> {
     let fd = fd.as_fd();
-    let new = new.into_fd();
     imp::syscalls::dup2(fd, new)
 }
 
@@ -116,13 +115,8 @@ pub fn dup2<Fd: AsFd, NewFd: IntoFd>(fd: &Fd, new: NewFd) -> io::Result<OwnedFd>
 #[cfg(not(target_os = "wasi"))]
 #[inline]
 #[doc(alias = "dup3")]
-pub fn dup2_with<Fd: AsFd, NewFd: IntoFd>(
-    fd: &Fd,
-    new: NewFd,
-    flags: DupFlags,
-) -> io::Result<OwnedFd> {
+pub fn dup2_with<Fd: AsFd>(fd: &Fd, new: &OwnedFd, flags: DupFlags) -> io::Result<()> {
     let fd = fd.as_fd();
-    let new = new.into_fd();
     imp::syscalls::dup2_with(fd, new, flags)
 }
 

--- a/tests/io/dup2_to_replace_stdio.rs
+++ b/tests/io/dup2_to_replace_stdio.rs
@@ -7,11 +7,11 @@ fn dup2_to_replace_stdio() {
     use std::mem::forget;
 
     let (reader, writer) = pipe().unwrap();
-
-    unsafe {
-        forget(dup2(&reader, posish::io::take_stdin()).unwrap());
-        forget(dup2(&writer, posish::io::take_stdout()).unwrap());
-    }
+    let (stdin, stdout) = unsafe { (posish::io::take_stdin(), posish::io::take_stdout()) };
+    dup2(&reader, &stdin).unwrap();
+    dup2(&writer, &stdout).unwrap();
+    forget(stdin);
+    forget(stdout);
 
     drop(reader);
     drop(writer);


### PR DESCRIPTION
This still requires that the caller own the new fd, but this way it
doesn't leak the fd if the `dup2` fails.