### PR TITLE
Avoid depending on libc for close.

### DIFF
--- a/src/imp/libc/syscalls.rs
+++ b/src/imp/libc/syscalls.rs
@@ -80,7 +80,10 @@ use super::{
     io::ReadWriteFlags,
     offset::{libc_preadv2, libc_pwritev2},
 };
-use crate::{as_ptr, io};
+use crate::{
+    as_ptr,
+    io::{self, RawFd},
+};
 use errno::errno;
 use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(not(any(target_os = "wasi", target_os = "fuchsia")))]
@@ -302,6 +305,10 @@ fn query_max_iov() -> usize {
 #[inline]
 fn max_iov() -> usize {
     16 // The minimum value required by POSIX.
+}
+
+pub(crate) unsafe fn close(raw_fd: RawFd) {
+    let _ = libc::close(raw_fd as c_int);
 }
 
 #[cfg(not(target_os = "redox"))]

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{
     as_mut_ptr, as_ptr, io,
-    io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+    io::{AsRawFd, FromRawFd, RawFd},
 };
 use io_lifetimes::{BorrowedFd, OwnedFd};
 #[cfg(target_pointer_width = "64")]
@@ -81,12 +81,6 @@ pub(super) fn borrowed_fd(fd: BorrowedFd<'_>) -> usize {
     // File descriptors are never negative on Linux, so use zero-extension
     // rather than sign-extension because it's a smaller instruction.
     fd.as_raw_fd() as c_uint as usize
-}
-
-#[inline]
-pub(super) fn owned_fd(fd: OwnedFd) -> usize {
-    // As above, use zero-extension rather than sign-extension.
-    fd.into_raw_fd() as c_uint as usize
 }
 
 #[inline]

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -25,8 +25,8 @@ use super::arch::choose::{
 use super::conv::opt_ref;
 use super::conv::{
     borrowed_fd, by_mut, by_ref, c_int, c_str, c_uint, clockid_t, dev_t, mode_as, oflags,
-    opt_c_str, opt_mut, out, owned_fd, ret, ret_c_int, ret_c_uint, ret_discarded_fd, ret_owned_fd,
-    ret_usize, ret_void_star, slice_addr, slice_as_mut_ptr, socklen_t, void_star,
+    opt_c_str, opt_mut, out, ret, ret_c_int, ret_c_uint, ret_discarded_fd, ret_owned_fd, ret_usize,
+    ret_void_star, slice_addr, slice_as_mut_ptr, socklen_t, void_star,
 };
 use super::fs::{
     Access, Advice, AtFlags, FallocateFlags, FdFlags, MemfdFlags, Mode, OFlags, ResolveFlags,
@@ -46,6 +46,7 @@ use super::rand::GetRandomFlags;
 use super::time::ClockId;
 use super::{fs::Stat, time::Timespec};
 use crate::io;
+use crate::io::RawFd;
 use crate::time::NanosleepRelativeResult;
 use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(not(any(target_arch = "riscv64")))]
@@ -151,10 +152,8 @@ pub(crate) fn exit_group(code: c_int) -> ! {
 }
 
 #[inline]
-pub(crate) fn close(fd: OwnedFd) {
-    unsafe {
-        let _ = syscall1_readonly(__NR_close, owned_fd(fd));
-    }
+pub(crate) unsafe fn close(raw_fd: RawFd) {
+    let _ = syscall1_readonly(__NR_close, raw_fd as isize as usize);
 }
 
 #[inline]

--- a/src/imp/linux_raw/vdso.rs
+++ b/src/imp/linux_raw/vdso.rs
@@ -15,7 +15,10 @@
 #![allow(non_upper_case_globals)]
 
 use super::fs::{Mode, OFlags};
-use crate::{fs::openat, io::proc_self};
+use crate::{
+    fs::openat,
+    io::{proc_self, OwnedFd},
+};
 use io_lifetimes::AsFilelike;
 use std::{
     ffi::CStr,
@@ -284,13 +287,15 @@ unsafe fn init_from_auxv(auxv: *const u8) -> Option<Vdso> {
 }
 
 fn init_from_proc_self_auxv() -> Option<Vdso> {
-    let auxv = openat(
+    let auxv: OwnedFd = match openat(
         &proc_self().ok()?.0,
         "auxv",
         OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NOCTTY,
         Mode::empty(),
-    )
-    .ok()?;
+    ) {
+        Ok(file) => file.into(),
+        Err(_err) => return None,
+    };
 
     let mut auxv_bytes = Vec::new();
     auxv.as_filelike_view::<File>()

--- a/src/io/fd.rs
+++ b/src/io/fd.rs
@@ -1,6 +1,9 @@
 //! Functions which operate on file descriptors.
 
-use crate::{imp, io};
+use crate::{
+    imp,
+    io::{self, RawFd},
+};
 use io_lifetimes::{AsFd, OwnedFd};
 #[cfg(all(libc, not(any(target_os = "wasi", target_os = "fuchsia"))))]
 use std::ffi::OsString;
@@ -136,4 +139,17 @@ pub fn dup2_with<Fd: AsFd>(fd: &Fd, new: &OwnedFd, flags: DupFlags) -> io::Resul
 pub fn ttyname<Fd: AsFd>(dirfd: &Fd, reuse: OsString) -> io::Result<OsString> {
     let dirfd = dirfd.as_fd();
     imp::syscalls::ttyname(dirfd, reuse)
+}
+
+/// `close(raw_fd)`—Closes a `RawFd` directly.
+///
+/// Most users won't need to use this, as `OwnedFd` automatically closes its
+/// file descriptor on `Drop`.
+///
+/// # Safety
+///
+/// This function takes a `RawFd`, which must be valid before the call, and is
+/// not valid after the call.
+pub unsafe fn close(raw_fd: RawFd) {
+    imp::syscalls::close(raw_fd)
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,11 +1,15 @@
 //! I/O operations.
 
+#![allow(unsafe_code)]
+
 use crate::imp;
 #[cfg(not(target_os = "wasi"))]
 use imp::io::Tcflag;
 
+#[allow(unused_imports)]
 #[cfg(unix)]
 pub(crate) use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[allow(unused_imports)]
 #[cfg(target_os = "wasi")]
 pub(crate) use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
@@ -16,6 +20,7 @@ mod fd;
 mod ioctl;
 #[cfg(not(target_os = "wasi"))]
 mod mmap;
+mod owned_fd;
 #[cfg(not(target_os = "wasi"))]
 mod pipe;
 mod poll;
@@ -33,9 +38,9 @@ pub use eventfd::{eventfd, EventfdFlags};
 pub use fd::ioctl_fionread;
 #[cfg(not(target_os = "redox"))]
 pub use fd::is_read_write;
-pub use fd::isatty;
 #[cfg(all(libc, not(any(target_os = "wasi", target_os = "fuchsia"))))]
 pub use fd::ttyname;
+pub use fd::{close, isatty};
 #[cfg(not(target_os = "wasi"))]
 pub use fd::{dup, dup2, dup2_with, DupFlags};
 #[cfg(any(target_os = "ios", target_os = "macos"))]
@@ -44,6 +49,7 @@ pub use ioctl::ioctl_fioclex;
 pub use ioctl::{ioctl_tcgets, ioctl_tiocgwinsz};
 #[cfg(not(target_os = "wasi"))]
 pub use mmap::{mmap, munmap, MapFlags, ProtFlags};
+pub use owned_fd::OwnedFd;
 #[cfg(not(target_os = "wasi"))]
 pub use pipe::pipe;
 #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "wasi")))]

--- a/src/io/owned_fd.rs
+++ b/src/io/owned_fd.rs
@@ -1,0 +1,60 @@
+use crate::io::{close, AsRawFd, FromRawFd};
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd};
+use std::{fmt, mem::ManuallyDrop};
+
+/// A wrapper around `io_lifetimes::OwnedFd` which closes the file descriptor
+/// using posish's own `close` rather than libc's `close`.
+#[repr(transparent)]
+pub struct OwnedFd {
+    inner: ManuallyDrop<io_lifetimes::OwnedFd>,
+}
+
+impl AsFd for OwnedFd {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.as_fd()
+    }
+}
+
+impl IntoFd for OwnedFd {
+    #[inline]
+    fn into_fd(self) -> io_lifetimes::OwnedFd {
+        unsafe { io_lifetimes::OwnedFd::from_raw_fd(self.inner.as_fd().as_raw_fd()) }
+    }
+}
+
+impl FromFd for OwnedFd {
+    #[inline]
+    fn from_fd(owned_fd: io_lifetimes::OwnedFd) -> Self {
+        Self {
+            inner: ManuallyDrop::new(owned_fd),
+        }
+    }
+}
+
+impl From<io_lifetimes::OwnedFd> for OwnedFd {
+    fn from(fd: io_lifetimes::OwnedFd) -> Self {
+        Self::from_fd(fd)
+    }
+}
+
+impl From<OwnedFd> for io_lifetimes::OwnedFd {
+    fn from(fd: OwnedFd) -> Self {
+        fd.into_fd()
+    }
+}
+
+impl Drop for OwnedFd {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            close(self.as_fd().as_raw_fd());
+        }
+    }
+}
+
+impl fmt::Debug for OwnedFd {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}


### PR DESCRIPTION
This introduces `posish::io::OwnedFd`, which is a wrapper around
`io_lifetimes::OwnedFd` and uses posish instead of libc to do the
`close`. This eliminates the last libc system call from posish.

This also introduces a `close` function, which takes a `RawFd` and
is `unsafe`.