### PR TITLE
A safe API for Linux epoll.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ errno = "0.2.7"
 libc = { version = "0.2.98", features = ["extra_traits"] }
 
 [target.'cfg(all(not(posish_use_libc), any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "aarch64", target_arch = "riscv64")))'.dependencies]
-linux-raw-sys = { version = "0.0.16", features = ["v5_4", "v5_11"] }
+linux-raw-sys = { version = "0.0.17", features = ["v5_4", "v5_11"] }
 cstr = "0.2.8"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,7 @@ fn main() {
             .channel
         {
             println!("cargo:rustc-cfg=linux_raw_inline_asm");
+            println!("cargo:rustc-cfg=const_fn_union");
         } else {
             Build::new().file(&asm_name).compile("asm");
             println!("cargo:rerun-if-changed={}", asm_name);

--- a/src/imp/libc/io/mod.rs
+++ b/src/imp/libc/io/mod.rs
@@ -2,6 +2,8 @@ mod error;
 mod poll_fd;
 mod types;
 
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub mod epoll;
 pub use error::Error;
 pub use poll_fd::{PollFd, PollFlags};
 #[cfg(any(

--- a/src/imp/libc/syscalls.rs
+++ b/src/imp/libc/syscalls.rs
@@ -921,6 +921,13 @@ pub(crate) fn ioctl_fionread(fd: BorrowedFd<'_>) -> io::Result<u64> {
     }
 }
 
+pub(crate) fn ioctl_fionbio(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
+    unsafe {
+        let data = value as c_int;
+        ret(libc::ioctl(borrowed_fd(fd), libc::FIONBIO, &data))
+    }
+}
+
 pub(crate) fn isatty(fd: BorrowedFd<'_>) -> bool {
     let res = unsafe { libc::isatty(borrowed_fd(fd)) };
     if res == 0 {

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -84,12 +84,6 @@ pub(super) fn borrowed_fd(fd: BorrowedFd<'_>) -> usize {
 }
 
 #[inline]
-pub(super) fn owned_fd(fd: OwnedFd) -> usize {
-    // As above, use zero-extension rather than sign-extension.
-    fd.into_raw_fd() as c_uint as usize
-}
-
-#[inline]
 pub(super) fn raw_fd(fd: c_int) -> usize {
     // As above, use zero-extension rather than sign-extension.
     fd as c_uint as usize

--- a/src/imp/linux_raw/conv.rs
+++ b/src/imp/linux_raw/conv.rs
@@ -84,6 +84,18 @@ pub(super) fn borrowed_fd(fd: BorrowedFd<'_>) -> usize {
 }
 
 #[inline]
+pub(super) fn owned_fd(fd: OwnedFd) -> usize {
+    // As above, use zero-extension rather than sign-extension.
+    fd.into_raw_fd() as c_uint as usize
+}
+
+#[inline]
+pub(super) fn raw_fd(fd: c_int) -> usize {
+    // As above, use zero-extension rather than sign-extension.
+    fd as c_uint as usize
+}
+
+#[inline]
 pub(super) fn slice_addr<T: Sized>(v: &[T]) -> usize {
     v.as_ptr() as usize
 }

--- a/src/imp/linux_raw/io/epoll.rs
+++ b/src/imp/linux_raw/io/epoll.rs
@@ -1,0 +1,424 @@
+//! epoll support.
+//!
+//! This is an experiment, and it isn't yet clear whether epoll is the right
+//! level of abstraction at which to introduce safety.
+#![allow(unsafe_code)]
+
+use super::super::syscalls::{epoll_add, epoll_create, epoll_del, epoll_mod, epoll_wait};
+use crate::{
+    io,
+    io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+};
+use bitflags::bitflags;
+use io_lifetimes::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
+use std::{
+    fmt,
+    marker::PhantomData,
+    ops::Deref,
+    os::raw::{c_int, c_uint},
+    ptr::null,
+};
+
+bitflags! {
+    /// `EPOLL_*` for use with [`Epoll::new`].
+    pub struct CreateFlags: c_uint {
+        /// `EPOLL_CLOEXEC`
+        const CLOEXEC = linux_raw_sys::general::EPOLL_CLOEXEC;
+    }
+}
+
+bitflags! {
+    /// `EPOLL*` for use with [`Epoll::add`].
+    #[derive(Default)]
+    pub struct EventFlags: u32 {
+        /// `EPOLLIN`
+        const IN = linux_raw_sys::general::EPOLLIN as u32;
+
+        /// `EPOLLOUT`
+        const OUT = linux_raw_sys::general::EPOLLOUT as u32;
+
+        /// `EPOLLPRI`
+        const PRI = linux_raw_sys::general::EPOLLPRI as u32;
+
+        /// `EPOLLERR`
+        const ERR = linux_raw_sys::general::EPOLLERR as u32;
+
+        /// `EPOLLHUP`
+        const HUP = linux_raw_sys::general::EPOLLHUP as u32;
+
+        /// `EPOLLET`
+        const ET = linux_raw_sys::general::EPOLLET as u32;
+
+        /// `EPOLLONESHOT`
+        const ONESHOT = linux_raw_sys::general::EPOLLONESHOT as u32;
+
+        /// `EPOLLWAKEUP`
+        const WAKEUP = linux_raw_sys::general::EPOLLWAKEUP as u32;
+
+        /// `EPOLLEXCLUSIVE`
+        const EXCLUSIVE = linux_raw_sys::general::EPOLLEXCLUSIVE as u32;
+    }
+}
+
+/// A reference to a `T`.
+pub struct Ref<'a, T> {
+    t: T,
+    _phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T> Ref<'a, T> {
+    #[inline]
+    fn new(t: T) -> Self {
+        Self {
+            t,
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn consume(self) -> T {
+        self.t
+    }
+}
+
+impl<'a, T> Deref for Ref<'a, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.t
+    }
+}
+
+impl<'a, T: fmt::Debug> fmt::Debug for Ref<'a, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.t.fmt(fmt)
+    }
+}
+
+/// A trait for data stored within an [`Epoll`] instance.
+pub trait Context {
+    /// The type of an element owned by this context.
+    type Data;
+
+    /// The type of a value used to refer to an element owned by this context.
+    type Target: AsFd;
+
+    /// Assume ownership of `data`, and returning a `Target`.
+    fn acquire<'call>(&self, data: Self::Data) -> Ref<'call, Self::Target>;
+
+    /// Encode `target` as a `u64`. The only requirement on this value is that
+    /// it be decodable by `decode`.
+    fn encode(&self, target: Ref<'_, Self::Target>) -> u64;
+
+    /// Decode `raw`, which is a value encoded by `encode`, into a `Target`.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be a `u64` value returned from `encode`, from the same
+    /// context, and within the context's lifetime.
+    unsafe fn decode<'call>(&self, raw: u64) -> Ref<'call, Self::Target>;
+
+    /// Release ownership of the value refered to by `target` and return it.
+    fn release(&self, target: Ref<'_, Self::Target>) -> Self::Data;
+}
+
+/// A type implementing [`Context`] where the `Data` type is `BorrowedFd<'a>`.
+pub struct Borrowing<'a> {
+    _phantom: PhantomData<BorrowedFd<'a>>,
+}
+
+impl<'a> Context for Borrowing<'a> {
+    type Data = BorrowedFd<'a>;
+    type Target = BorrowedFd<'a>;
+
+    #[inline]
+    fn acquire<'call>(&self, data: Self::Data) -> Ref<'call, Self::Target> {
+        Ref::new(data)
+    }
+
+    #[inline]
+    fn encode(&self, target: Ref<'_, Self::Target>) -> u64 {
+        target.as_raw_fd() as u64
+    }
+
+    #[inline]
+    unsafe fn decode<'call>(&self, raw: u64) -> Ref<'call, Self::Target> {
+        Ref::new(BorrowedFd::<'a>::borrow_raw_fd(raw as RawFd))
+    }
+
+    #[inline]
+    fn release(&self, target: Ref<'_, Self::Target>) -> Self::Data {
+        target.consume()
+    }
+}
+
+/// A type implementing [`Context`] where the `Data` type is `T`, a type
+/// implementing `IntoFd` and `FromFd`.
+///
+/// This may be used with [`OwnedFd`], or higher-level types like
+/// [`std::fs::File`] or [`std::net::TcpStream`].
+pub struct Owning<'context, T: IntoFd + FromFd> {
+    _phantom: PhantomData<&'context T>,
+}
+
+impl<'context, T: IntoFd + FromFd> Owning<'context, T> {
+    /// Creates a new empty `Owning`.
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'context, T: AsFd + IntoFd + FromFd> Context for Owning<'context, T> {
+    type Data = T;
+    type Target = BorrowedFd<'context>;
+
+    #[inline]
+    fn acquire<'call>(&self, data: Self::Data) -> Ref<'call, Self::Target> {
+        let raw_fd = data.into_fd().into_raw_fd();
+        // Safety: `epoll` will assign ownership of the file descriptor to the
+        // kernel epoll object. We use `IntoFd`+`IntoRawFd` to consume the
+        // `Data` and extract the raw file descriptor and then "borrow" it
+        // with `borrow_raw_fd` knowing that the borrow won't outlive the
+        // kernel epoll object.
+        unsafe { Ref::new(BorrowedFd::<'context>::borrow_raw_fd(raw_fd)) }
+    }
+
+    #[inline]
+    fn encode(&self, target: Ref<'_, Self::Target>) -> u64 {
+        target.as_fd().as_raw_fd() as u64
+    }
+
+    #[inline]
+    unsafe fn decode<'call>(&self, raw: u64) -> Ref<'call, Self::Target> {
+        Ref::new(BorrowedFd::<'context>::borrow_raw_fd(raw as RawFd))
+    }
+
+    #[inline]
+    fn release(&self, target: Ref<'_, Self::Target>) -> Self::Data {
+        // The file descriptor was held by the kernel epoll object and is now
+        // being released, so we can create a new `OwnedFd` that assumes
+        // ownership.
+        let raw_fd = target.consume().as_raw_fd();
+        unsafe { T::from_fd(OwnedFd::from_raw_fd(raw_fd)) }
+    }
+}
+
+/// An "epoll", an interface to an OS object allowing one to repeatedly wait
+/// for events from a set of file descriptors efficiently.
+pub struct Epoll<Context: self::Context> {
+    epoll_fd: OwnedFd,
+    context: Context,
+}
+
+impl<Context: self::Context> Epoll<Context> {
+    /// `epoll_create1(flags)`—Creates a new `Epoll`.
+    ///
+    /// Use the [`CreateFlags::CLOEXEC`] flag to prevent the resulting file
+    /// descriptor from being implicity passed across `exec` boundaries.
+    #[inline]
+    #[doc(alias = "epoll_create1")]
+    pub fn new(flags: CreateFlags, context: Context) -> io::Result<Self> {
+        // Safety: We're calling `epoll_create1` via FFI and we know how it
+        // behaves.
+        Ok(Self {
+            epoll_fd: epoll_create(flags)?,
+            context,
+        })
+    }
+
+    /// `epoll_ctl(self, EPOLL_CTL_ADD, fd, event)`—Adds an element to an
+    /// `Epoll`.
+    ///
+    /// This registers interest in any of the events set in `events` occuring
+    /// on the file descriptor associated with `data`.
+    #[doc(alias = "epoll_ctl")]
+    pub fn add(
+        &self,
+        data: Context::Data,
+        event_flags: EventFlags,
+    ) -> io::Result<Ref<'_, Context::Target>> {
+        // Safety: We're calling `epoll_ctl` via FFI and we know how it
+        // behaves.
+        unsafe {
+            let target = self.context.acquire(data);
+            let raw_fd = target.as_fd().as_raw_fd();
+            let encoded = self.context.encode(target);
+            epoll_add(
+                self.epoll_fd.as_fd(),
+                raw_fd,
+                &linux_raw_sys::general::epoll_event {
+                    events: event_flags.bits(),
+                    data: encoded,
+                },
+            )?;
+            Ok(self.context.decode(encoded))
+        }
+    }
+
+    /// `epoll_ctl(self, EPOLL_CTL_MOD, fd, event)`—Modifies an element in
+    /// this `Epoll`.
+    ///
+    /// This sets the events of interest with `target` to `events`.
+    #[doc(alias = "epoll_ctl")]
+    pub fn mod_(
+        &self,
+        target: Ref<'_, Context::Target>,
+        event_flags: EventFlags,
+    ) -> io::Result<()> {
+        let raw_fd = target.as_fd().as_raw_fd();
+        let encoded = self.context.encode(target);
+        // Safety: We're calling `epoll_ctl` via FFI and we know how it
+        // behaves.
+        unsafe {
+            epoll_mod(
+                self.epoll_fd.as_fd(),
+                raw_fd,
+                &linux_raw_sys::general::epoll_event {
+                    events: event_flags.bits(),
+                    data: encoded,
+                },
+            )
+        }
+    }
+
+    /// `epoll_ctl(self, EPOLL_CTL_DEL, fd, NULL)`—Removes an element in
+    /// this `Epoll`.
+    ///
+    /// This also returns the owning `Data`.
+    #[doc(alias = "epoll_ctl")]
+    pub fn del(&self, target: Ref<'_, Context::Target>) -> io::Result<Context::Data> {
+        // Safety: We're calling `epoll_ctl` via FFI and we know how it
+        // behaves.
+        unsafe {
+            let raw_fd = target.as_fd().as_raw_fd();
+            epoll_del(self.epoll_fd.as_fd(), raw_fd)?;
+        }
+        Ok(self.context.release(target))
+    }
+
+    /// `epoll_wait(self, events, timeout)`—Waits for registered events of
+    /// interest.
+    ///
+    /// For each event of interest, an element is written to `events`. On
+    /// success, this returns the number of written elements.
+    #[doc(alias = "epoll_wait")]
+    pub fn wait<'context>(
+        &'context self,
+        event_list: &mut EventVec<'context, Context>,
+        timeout: c_int,
+    ) -> io::Result<()> {
+        // Safety: We're calling `epoll_wait` via FFI and we know how it
+        // behaves.
+        unsafe {
+            event_list.events.set_len(0);
+            let nfds = epoll_wait(
+                self.epoll_fd.as_fd(),
+                event_list.events[..].as_mut_ptr() as *mut _,
+                event_list.events.capacity(),
+                timeout,
+            )?;
+            event_list.events.set_len(nfds);
+            event_list.context = &self.context;
+        }
+
+        Ok(())
+    }
+}
+
+pub struct Iter<'context, Context: self::Context> {
+    iter: std::slice::Iter<'context, Event>,
+    context: *const Context,
+    _phantom: PhantomData<&'context Context>,
+}
+
+impl<'context, Context: self::Context> Iterator for Iter<'context, Context> {
+    type Item = (EventFlags, Ref<'context, Context::Target>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Safety: `self.context` is guaranteed to be valid because we hold
+        // `'context` for it. And we know this event is associated with this
+        // context because `wait` sets both.
+        self.iter.next().map(|event| {
+            (event.event_flags, unsafe {
+                (*self.context).decode(event.encoded)
+            })
+        })
+    }
+}
+
+/// A record of an event that occurred.
+#[repr(C)]
+#[cfg_attr(target_arch = "x86_64", repr(packed))]
+struct Event {
+    // Match the layout of `linux_raw_sys::general::epoll_event`. We just use a
+    // `u64` instead of the full union; `Context` implementations will simply
+    // need to deal with casting the value into and out of the `u64`
+    // themselves.
+    event_flags: EventFlags,
+    encoded: u64,
+}
+
+pub struct EventVec<'context, Context: self::Context> {
+    events: Vec<Event>,
+    context: *const Context,
+    _phantom: PhantomData<&'context Context>,
+}
+
+impl<'context, Context: self::Context> EventVec<'context, Context> {
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            events: Vec::with_capacity(capacity),
+            context: null(),
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.events.capacity()
+    }
+
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.events.reserve(additional);
+    }
+
+    #[inline]
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.events.reserve_exact(additional);
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.events.clear();
+    }
+
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.events.shrink_to_fit();
+    }
+
+    #[inline]
+    pub fn iter(&self) -> Iter<'_, Context> {
+        Iter {
+            iter: self.events.iter(),
+            context: self.context,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'context, Context: self::Context> IntoIterator for &'context EventVec<'context, Context> {
+    type IntoIter = Iter<'context, Context>;
+    type Item = (EventFlags, Ref<'context, Context::Target>);
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}

--- a/src/imp/linux_raw/io/mod.rs
+++ b/src/imp/linux_raw/io/mod.rs
@@ -1,3 +1,4 @@
+pub mod epoll;
 mod error;
 mod poll_fd;
 mod types;

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -25,8 +25,8 @@ use super::arch::choose::{
 use super::conv::opt_ref;
 use super::conv::{
     borrowed_fd, by_mut, by_ref, c_int, c_str, c_uint, clockid_t, dev_t, mode_as, oflags,
-    opt_c_str, opt_mut, out, owned_fd, raw_fd, ret, ret_c_int, ret_c_uint, ret_discarded_fd,
-    ret_owned_fd, ret_usize, ret_void_star, slice_addr, slice_as_mut_ptr, socklen_t, void_star,
+    opt_c_str, opt_mut, out, raw_fd, ret, ret_c_int, ret_c_uint, ret_discarded_fd, ret_owned_fd,
+    ret_usize, ret_void_star, slice_addr, slice_as_mut_ptr, socklen_t, void_star,
 };
 use super::fs::{
     Access, Advice, AtFlags, FallocateFlags, FdFlags, MemfdFlags, Mode, OFlags, ResolveFlags,

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -49,9 +49,9 @@ use crate::io;
 use crate::io::RawFd;
 use crate::time::NanosleepRelativeResult;
 use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
-#[cfg(target_arch = "riscv64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use linux_raw_sys::general::__NR_epoll_pwait;
-#[cfg(not(target_arch = "riscv64"))]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
 use linux_raw_sys::general::__NR_epoll_wait;
 #[cfg(not(any(target_arch = "riscv64")))]
 use linux_raw_sys::general::__NR_renameat;
@@ -2832,7 +2832,7 @@ pub(crate) fn epoll_wait(
     num_events: usize,
     timeout: c_int,
 ) -> io::Result<usize> {
-    #[cfg(not(target_arch = "riscv64"))]
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
     unsafe {
         ret_usize(syscall4(
             __NR_epoll_wait,
@@ -2842,7 +2842,7 @@ pub(crate) fn epoll_wait(
             c_int(timeout),
         ))
     }
-    #[cfg(target_arch = "riscv64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     unsafe {
         ret_usize(syscall5(
             __NR_epoll_pwait,

--- a/src/imp/linux_raw/syscalls.rs
+++ b/src/imp/linux_raw/syscalls.rs
@@ -25,15 +25,15 @@ use super::arch::choose::{
 use super::conv::opt_ref;
 use super::conv::{
     borrowed_fd, by_mut, by_ref, c_int, c_str, c_uint, clockid_t, dev_t, mode_as, oflags,
-    opt_c_str, opt_mut, out, ret, ret_c_int, ret_c_uint, ret_discarded_fd, ret_owned_fd, ret_usize,
-    ret_void_star, slice_addr, slice_as_mut_ptr, socklen_t, void_star,
+    opt_c_str, opt_mut, out, owned_fd, raw_fd, ret, ret_c_int, ret_c_uint, ret_discarded_fd,
+    ret_owned_fd, ret_usize, ret_void_star, slice_addr, slice_as_mut_ptr, socklen_t, void_star,
 };
 use super::fs::{
     Access, Advice, AtFlags, FallocateFlags, FdFlags, MemfdFlags, Mode, OFlags, ResolveFlags,
     StatFs, StatxFlags,
 };
 use super::io::{
-    DupFlags, EventfdFlags, MapFlags, PipeFlags, PollFd, ProtFlags, ReadWriteFlags,
+    epoll, DupFlags, EventfdFlags, MapFlags, PipeFlags, PollFd, ProtFlags, ReadWriteFlags,
     UserfaultfdFlags,
 };
 #[cfg(not(target_os = "wasi"))]
@@ -77,21 +77,21 @@ use linux_raw_sys::general::{__NR_recv, __NR_send};
 use linux_raw_sys::{
     general::{
         __NR_chdir, __NR_clock_getres, __NR_clock_nanosleep, __NR_close, __NR_dup, __NR_dup3,
-        __NR_exit_group, __NR_faccessat, __NR_fallocate, __NR_fchmod, __NR_fchmodat,
-        __NR_fdatasync, __NR_fsync, __NR_getcwd, __NR_getdents64, __NR_getpid, __NR_getppid,
-        __NR_ioctl, __NR_linkat, __NR_mkdirat, __NR_mknodat, __NR_munmap, __NR_nanosleep,
-        __NR_openat, __NR_pipe2, __NR_pread64, __NR_preadv, __NR_pwrite64, __NR_pwritev, __NR_read,
-        __NR_readlinkat, __NR_readv, __NR_sched_yield, __NR_symlinkat, __NR_unlinkat,
-        __NR_utimensat, __NR_write, __NR_writev,
+        __NR_epoll_create1, __NR_epoll_ctl, __NR_epoll_wait, __NR_exit_group, __NR_faccessat,
+        __NR_fallocate, __NR_fchmod, __NR_fchmodat, __NR_fdatasync, __NR_fsync, __NR_getcwd,
+        __NR_getdents64, __NR_getpid, __NR_getppid, __NR_ioctl, __NR_linkat, __NR_mkdirat,
+        __NR_mknodat, __NR_munmap, __NR_nanosleep, __NR_openat, __NR_pipe2, __NR_pread64,
+        __NR_preadv, __NR_pwrite64, __NR_pwritev, __NR_read, __NR_readlinkat, __NR_readv,
+        __NR_sched_yield, __NR_symlinkat, __NR_unlinkat, __NR_utimensat, __NR_write, __NR_writev,
     },
     general::{
-        __kernel_gid_t, __kernel_pid_t, __kernel_timespec, __kernel_uid_t, sockaddr, sockaddr_in,
-        sockaddr_in6, sockaddr_un, socklen_t,
+        __kernel_gid_t, __kernel_pid_t, __kernel_timespec, __kernel_uid_t, epoll_event, sockaddr,
+        sockaddr_in, sockaddr_in6, sockaddr_un, socklen_t,
     },
     general::{
-        AT_FDCWD, AT_REMOVEDIR, AT_SYMLINK_NOFOLLOW, FIONREAD, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD,
-        F_GETFL, F_GETLEASE, F_GETOWN, F_GETSIG, F_SETFD, F_SETFL, TCGETS, TIMER_ABSTIME,
-        TIOCGWINSZ,
+        AT_FDCWD, AT_REMOVEDIR, AT_SYMLINK_NOFOLLOW, EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD,
+        FIONBIO, FIONREAD, F_DUPFD, F_DUPFD_CLOEXEC, F_GETFD, F_GETFL, F_GETLEASE, F_GETOWN,
+        F_GETSIG, F_SETFD, F_SETFL, TCGETS, TIMER_ABSTIME, TIOCGWINSZ,
     },
     v5_11::{general::__NR_openat2, general::open_how},
     v5_4::{
@@ -2431,6 +2431,19 @@ pub(crate) fn ioctl_fionread(fd: BorrowedFd) -> io::Result<u64> {
 }
 
 #[inline]
+pub(crate) fn ioctl_fionbio(fd: BorrowedFd<'_>, value: bool) -> io::Result<()> {
+    unsafe {
+        let data = value as c_int;
+        ret(syscall3(
+            __NR_ioctl,
+            borrowed_fd(fd),
+            c_uint(FIONBIO),
+            by_ref(&data),
+        ))
+    }
+}
+
+#[inline]
 pub(crate) fn ioctl_tiocgwinsz(fd: BorrowedFd) -> io::Result<Winsize> {
     unsafe {
         let mut result = MaybeUninit::<Winsize>::uninit();
@@ -2760,4 +2773,68 @@ pub(crate) fn is_read_write(fd: BorrowedFd<'_>) -> io::Result<(bool, bool)> {
         }
     }
     Ok((read, write))
+}
+
+#[inline]
+pub(crate) fn epoll_create(flags: epoll::CreateFlags) -> io::Result<OwnedFd> {
+    unsafe { ret_owned_fd(syscall1(__NR_epoll_create1, c_uint(flags.bits()))) }
+}
+
+#[inline]
+pub(crate) unsafe fn epoll_add(
+    epfd: BorrowedFd<'_>,
+    fd: c_int,
+    event: &epoll_event,
+) -> io::Result<()> {
+    ret(syscall4(
+        __NR_epoll_ctl,
+        borrowed_fd(epfd),
+        c_uint(EPOLL_CTL_ADD),
+        raw_fd(fd),
+        by_ref(event),
+    ))
+}
+
+#[inline]
+pub(crate) unsafe fn epoll_mod(
+    epfd: BorrowedFd<'_>,
+    fd: c_int,
+    event: &epoll_event,
+) -> io::Result<()> {
+    ret(syscall4(
+        __NR_epoll_ctl,
+        borrowed_fd(epfd),
+        c_uint(EPOLL_CTL_MOD),
+        raw_fd(fd),
+        by_ref(event),
+    ))
+}
+
+#[inline]
+pub(crate) unsafe fn epoll_del(epfd: BorrowedFd<'_>, fd: c_int) -> io::Result<()> {
+    ret(syscall4(
+        __NR_epoll_ctl,
+        borrowed_fd(epfd),
+        c_uint(EPOLL_CTL_DEL),
+        raw_fd(fd),
+        0,
+    ))
+}
+
+#[inline]
+pub(crate) fn epoll_wait(
+    epfd: BorrowedFd<'_>,
+    events: *mut epoll_event,
+    num_events: usize,
+    timeout: c_int,
+) -> io::Result<usize> {
+    unsafe {
+        ret_usize(syscall4(
+            __NR_epoll_wait,
+            borrowed_fd(epfd),
+            events as usize,
+            num_events,
+            c_int(timeout),
+        ))
+    }
 }

--- a/src/io/ioctl.rs
+++ b/src/io/ioctl.rs
@@ -1,6 +1,7 @@
 use crate::imp;
+use crate::io;
 #[cfg(not(target_os = "wasi"))]
-use crate::io::{self, Termios, Winsize};
+use crate::io::{Termios, Winsize};
 use io_lifetimes::{AsFd, BorrowedFd};
 
 /// `ioctl(fd, TCGETS)`
@@ -42,4 +43,11 @@ pub fn ioctl_fioclex<Fd: AsFd>(fd: &Fd) -> io::Result<()> {
 pub fn ioctl_tiocgwinsz(fd: BorrowedFd) -> io::Result<Winsize> {
     let fd = fd.as_fd();
     imp::syscalls::ioctl_tiocgwinsz(fd)
+}
+
+/// `ioctl(fd, FIONBIO, &value)`—Enables or disables non-blocking mode.
+#[inline]
+pub fn ioctl_fionbio<Fd: AsFd>(fd: &Fd, value: bool) -> io::Result<()> {
+    let fd = fd.as_fd();
+    imp::syscalls::ioctl_fionbio(fd, value)
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -43,8 +43,11 @@ pub use fd::ttyname;
 pub use fd::{close, isatty};
 #[cfg(not(target_os = "wasi"))]
 pub use fd::{dup, dup2, dup2_with, DupFlags};
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub use imp::io::epoll;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub use ioctl::ioctl_fioclex;
+pub use ioctl::ioctl_fionbio;
 #[cfg(not(target_os = "wasi"))]
 pub use ioctl::{ioctl_tcgets, ioctl_tiocgwinsz};
 #[cfg(not(target_os = "wasi"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(linux_raw, deny(unsafe_code))]
 #![cfg_attr(linux_raw_inline_asm, feature(asm))]
+#![cfg_attr(const_fn_union, feature(const_fn_union))]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(
     all(linux_raw_inline_asm, target_arch = "x86"),

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -2,6 +2,7 @@
 
 mod io {
     mod dup2_to_replace_stdio;
+    mod epoll;
     mod eventfd;
     mod isatty;
     mod mmap;

--- a/tests/io/epoll.rs
+++ b/tests/io/epoll.rs
@@ -1,0 +1,94 @@
+#![cfg(any(target_os = "linux", target_os = "android"))]
+
+use posish::io::{
+    epoll::{self, Epoll},
+    ioctl_fionbio, read, write,
+};
+use posish::net::{
+    accept, bind_v4, connect_v4, getsockname, listen, socket, AddressFamily, Ipv4Addr, Protocol,
+    SocketAddr, SocketAddrV4, SocketType,
+};
+use std::os::unix::io::AsRawFd;
+use std::{
+    sync::{Arc, Condvar, Mutex},
+    thread,
+};
+
+const BUFFER_SIZE: usize = 20;
+
+fn server(ready: Arc<(Mutex<u16>, Condvar)>) {
+    let listen_sock = socket(AddressFamily::INET, SocketType::STREAM, Protocol::default()).unwrap();
+    bind_v4(&listen_sock, &SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
+    listen(&listen_sock, 1).unwrap();
+
+    let who = match getsockname(&listen_sock).unwrap() {
+        SocketAddr::V4(addr) => addr,
+        _ => panic!(),
+    };
+
+    {
+        let (lock, cvar) = &*ready;
+        let mut port = lock.lock().unwrap();
+        *port = who.port();
+        cvar.notify_all();
+    }
+
+    let epoll = Epoll::new(epoll::CreateFlags::CLOEXEC, epoll::Owning::new()).unwrap();
+
+    let raw_listen_sock = listen_sock.as_raw_fd();
+    epoll.add(listen_sock, epoll::EventFlags::IN).unwrap();
+
+    let mut event_list = epoll::EventVec::with_capacity(4);
+    loop {
+        epoll.wait(&mut event_list, -1).unwrap();
+        for (_event_flags, target) in &event_list {
+            if target.as_raw_fd() == raw_listen_sock {
+                let conn_sock = accept(&*target).unwrap();
+                ioctl_fionbio(&conn_sock, true).unwrap();
+                epoll
+                    .add(conn_sock, epoll::EventFlags::OUT | epoll::EventFlags::ET)
+                    .unwrap();
+            } else {
+                write(&*target, b"hello\n").unwrap();
+                let _ = epoll.del(target).unwrap();
+            }
+        }
+    }
+}
+
+fn client(ready: Arc<(Mutex<u16>, Condvar)>) {
+    let port = {
+        let (lock, cvar) = &*ready;
+        let mut port = lock.lock().unwrap();
+        while *port == 0 {
+            port = cvar.wait(port).unwrap();
+        }
+        *port
+    };
+
+    let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
+    let mut buffer = vec![0; BUFFER_SIZE];
+
+    for _ in 0..16 {
+        let data_socket =
+            socket(AddressFamily::INET, SocketType::STREAM, Protocol::default()).unwrap();
+        connect_v4(&data_socket, &addr).unwrap();
+
+        let nread = read(&data_socket, &mut buffer).unwrap();
+        assert_eq!(String::from_utf8_lossy(&buffer[..nread]), "hello\n");
+    }
+}
+
+#[test]
+fn test_epoll() {
+    let ready = Arc::new((Mutex::new(0_u16), Condvar::new()));
+    let ready_clone = Arc::clone(&ready);
+
+    let _server = thread::spawn(move || {
+        server(ready);
+    });
+    let client = thread::spawn(move || {
+        client(ready_clone);
+    });
+    client.join().unwrap();
+}


### PR DESCRIPTION
This is somewhat experimental, particularly the lifetime and buffer
parts, but it works for simple cases at least, so let's see how it goes.

This also adds `fcntl_fionbio`, for setting sockets to non-blocking.