### PR TITLE
Store Linux error codes in negated form.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ itoa = "0.4.7"
 io-lifetimes = "0.2.0"
 once_cell = "1.5.2"
 cstr = "0.2.8"
+const_fn_assert = "0.1.2"
 
 [target.'cfg(any(posish_use_libc, not(all(any(target_os = "linux"), any(target_arch = "x86", all(target_arch = "x86_64", not(target_pointer_width = "32")), target_arch = "aarch64", target_arch = "riscv64")))))'.dependencies]
 errno = "0.2.7"

--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,7 @@ fn main() {
         {
             println!("cargo:rustc-cfg=linux_raw_inline_asm");
             println!("cargo:rustc-cfg=const_fn_union");
+            println!("cargo:rustc-cfg=rustc_attrs");
         } else {
             Build::new().file(&asm_name).compile("asm");
             println!("cargo:rerun-if-changed={}", asm_name);

--- a/src/imp/linux_raw/io/mod.rs
+++ b/src/imp/linux_raw/io/mod.rs
@@ -12,6 +12,7 @@ pub use types::{
 
 use std::os::raw::{c_int, c_uint};
 
+pub(crate) use error::{check_fd, check_result, check_void};
 pub(crate) const AT_FDCWD: c_int = linux_raw_sys::general::AT_FDCWD;
 pub(crate) const STDIN_FILENO: c_uint = linux_raw_sys::general::STDIN_FILENO;
 pub(crate) const STDOUT_FILENO: c_uint = linux_raw_sys::general::STDOUT_FILENO;

--- a/src/io/error.rs
+++ b/src/io/error.rs
@@ -1,7 +1,7 @@
-//! The `Error` type, which is a minimal wrapper around an errno value.
+//! The `Error` type, which is a minimal wrapper around an error code.
 //!
-//! We define the errno constants as individual `const`s instead of an
-//! enum because we may not know about all of the host's errno values
+//! We define the error constants as individual `const`s instead of an
+//! enum because we may not know about all of the host's error values
 //! and we don't want unrecognized values to create UB.
 
 #![allow(missing_docs)]
@@ -12,7 +12,7 @@ use std::{error, fmt, result};
 /// A specialized `Result` type for posish APIs.
 pub type Result<T> = result::Result<T, Error>;
 
-/// `errno`
+/// `errno`—An error code.
 ///
 /// The error type for posish APIs. This is similar to `std::io::Error`, but
 /// only holds an OS error code, and no extra error value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 #![cfg_attr(linux_raw, deny(unsafe_code))]
 #![cfg_attr(linux_raw_inline_asm, feature(asm))]
 #![cfg_attr(const_fn_union, feature(const_fn_union))]
+#![cfg_attr(rustc_attrs, feature(rustc_attrs))]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![cfg_attr(
     all(linux_raw_inline_asm, target_arch = "x86"),


### PR DESCRIPTION
Linux reports errors by returning negative errno values. Instead of
negating them after every syscall to compute positive errno values,
just keep the values negatives, and convert the error constants to
negative form so that they match.

Also, remove the suppress_optimization mechanism, as the generated
code sequences are now different.